### PR TITLE
The reason for the table rather than other solutions is to keep refer…

### DIFF
--- a/draft-ietf-dnsop-dns-capture-format-00.md
+++ b/draft-ietf-dnsop-dns-capture-format-00.md
@@ -484,8 +484,6 @@ Class | CLASS value.
 ||
 Type | TYPE value.
 
-[TODO: Can this be optimized? Should a class of IN be inferred if not present?]
-
 ## Name/RDATA table
 
 This table holds the contents of all NAME or RDATA items in the block. Each item in the table is the content of a single NAME or RDATA.


### PR DESCRIPTION
…ences to a single byte.

Paul Hoffman spotted this. List email, 2/11/16.

Fixes #10